### PR TITLE
Removes SetInterval from CyclicPlugin

### DIFF
--- a/api/CyclicPlugin.h
+++ b/api/CyclicPlugin.h
@@ -12,6 +12,7 @@ namespace yapi {
 
     public:
         CyclicPlugin() : m_stopThread(false), m_interval(0) {};
+        explicit CyclicPlugin(std::chrono::milliseconds interval) : m_stopThread(false), m_interval(interval) {};
         virtual ~CyclicPlugin() {};
     public:
         virtual void SampleReceivedEvent(const std::string& pinName, const char*const buffer, const size_t bufferSize) = 0;
@@ -26,7 +27,7 @@ namespace yapi {
             );
 
         };
-        virtual void Stop() override {
+        virtual void Stop() override final{
 
             if (m_sendThread && m_sendThread->joinable()) {
                 m_stopThread = true;
@@ -35,15 +36,12 @@ namespace yapi {
         };
         virtual std::string GetPluginName() const = 0;
 
-        void SetInterval(std::chrono::milliseconds interval) {
-            m_interval = interval; //TODO: not thread-safe
-        };
         virtual void Cycle() = 0;
 
     private:
         std::unique_ptr<std::thread> m_sendThread;
         std::atomic_bool m_stopThread;
-        std::chrono::milliseconds m_interval;
+        const std::chrono::milliseconds m_interval;
 
     };
 }

--- a/lib/CyclicSenderPlugin.cpp
+++ b/lib/CyclicSenderPlugin.cpp
@@ -1,10 +1,9 @@
 #include "CyclicSenderPlugin.h"
 
 
-CyclicSenderPlugin::CyclicSenderPlugin() : m_pin("Output"), m_value(1000)
+CyclicSenderPlugin::CyclicSenderPlugin() : CyclicPlugin(std::chrono::milliseconds(100)), m_pin("Output"), m_value(1000)
 {
     RegisterPin(m_pin);
-    SetInterval(std::chrono::milliseconds(500));
 }
 
 CyclicSenderPlugin::~CyclicSenderPlugin()


### PR DESCRIPTION
As we currently do not see a use case for a run time change of
m_interval, this commit removes SetInterval. m_interval can now
only be initialized in the constructor of the derived class by
calling the explicit base class constructor.